### PR TITLE
Update libGDX to 1.13.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx512m -Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-8
 org.gradle.configureondemand=false
 # You can downgrade this for compatibility with older libGDX versions.
-gdxVersion=1.12.1
+gdxVersion=1.13.0
 lwjgl3Version=3.3.3
 
 # This must match your Maven Central group if you publish there; otherwise,

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xms128m -Xmx512m -Dfile.encoding=UTF-8 -Dconsole.encoding=UT
 org.gradle.configureondemand=false
 # You can downgrade this for compatibility with older libGDX versions.
 gdxVersion=1.13.0
-lwjgl3Version=3.3.3
+lwjgl3Version=3.3.4
 
 # This must match your Maven Central group if you publish there; otherwise,
 # change this template to match your group ID.
@@ -64,7 +64,7 @@ POM_LICENCE_DIST=repo
 
 # Obviously, change this part of the template if you aren't Tommy Ettinger.
 POM_DEVELOPER_ID=Dgzt
-POM_DEVELOPER_NAME=Zsuró Tibor
+POM_DEVELOPER_NAME=ZsurÃ³ Tibor
 POM_DEVELOPER_URL=https://github.com/Dgzt
 
 # These two lines allow uploading to Maven Central, if you want.

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/DefaultLwjgl3Input.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/DefaultLwjgl3Input.java
@@ -17,6 +17,7 @@
 package com.github.dgzt.gdx.lwjgl3;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Input;
+import com.badlogic.gdx.input.NativeInputConfiguration;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWCharCallback;
 import org.lwjgl.glfw.GLFWCursorPosCallback;
@@ -657,6 +658,21 @@ public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 
     @Override
     public void setOnscreenKeyboardVisible (boolean visible, OnscreenKeyboardType type) {
+    }
+
+    @Override
+    public void openTextInputField (NativeInputConfiguration configuration) {
+
+    }
+
+    @Override
+    public void closeTextInputField (boolean sendReturn) {
+
+    }
+
+    @Override
+    public void setKeyboardHeightObserver (KeyboardHeightObserver observer) {
+
     }
 
     @Override

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -19,6 +19,8 @@ package com.github.dgzt.gdx.lwjgl3;
 import java.io.PrintStream;
 import java.nio.IntBuffer;
 
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.LifecycleListener;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.GLFW;
@@ -32,6 +34,7 @@ import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.Graphics.Monitor;
 import com.badlogic.gdx.Preferences;
 import com.badlogic.gdx.audio.Music;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3Monitor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.graphics.glutils.HdpiUtils;
@@ -64,6 +67,9 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 
     int idleFPS = 60;
     int foregroundFPS = 0;
+
+    boolean pauseWhenMinimized = true;
+    boolean pauseWhenLostFocus = false;
 
     String preferencesDirectory = ".prefs/";
     Files.FileType preferencesFileType = FileType.External;
@@ -98,6 +104,8 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
         transparentFramebuffer = config.transparentFramebuffer;
         idleFPS = config.idleFPS;
         foregroundFPS = config.foregroundFPS;
+        pauseWhenMinimized = config.pauseWhenMinimized;
+        pauseWhenLostFocus = config.pauseWhenLostFocus;
         preferencesDirectory = config.preferencesDirectory;
         preferencesFileType = config.preferencesFileType;
         hdpiMode = config.hdpiMode;
@@ -182,6 +190,18 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
      * 0. */
     public void setForegroundFPS (int fps) {
         this.foregroundFPS = fps;
+    }
+
+    /** Sets whether to pause the application {@link ApplicationListener#pause()} and fire
+     * {@link LifecycleListener#pause()}/{@link LifecycleListener#resume()} events on when window is minimized/restored. **/
+    public void setPauseWhenMinimized (boolean pauseWhenMinimized) {
+        this.pauseWhenMinimized = pauseWhenMinimized;
+    }
+
+    /** Sets whether to pause the application {@link ApplicationListener#pause()} and fire
+     * {@link LifecycleListener#pause()}/{@link LifecycleListener#resume()} events on when window loses/gains focus. **/
+    public void setPauseWhenLostFocus (boolean pauseWhenLostFocus) {
+        this.pauseWhenLostFocus = pauseWhenLostFocus;
     }
 
     /** Sets the directory where {@link Preferences} will be stored, as well as the file type to be used to store them. Defaults to

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3Graphics.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3Graphics.java
@@ -20,7 +20,6 @@ import java.nio.IntBuffer;
 
 import com.badlogic.gdx.AbstractGraphics;
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3GL31;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3GL32;
@@ -74,37 +73,24 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
     IntBuffer tmpBuffer2 = BufferUtils.createIntBuffer(1);
 
     GLFWFramebufferSizeCallback resizeCallback = new GLFWFramebufferSizeCallback() {
-        volatile boolean posted;
-
         @Override
         public void invoke (long windowHandle, final int width, final int height) {
-            if (Configuration.GLFW_CHECK_THREAD0.get(true)) {
-                renderWindow(windowHandle, width, height);
+            if (!"glfw_async".equals(Configuration.GLFW_LIBRARY_NAME.get())) {
+                updateFramebufferInfo();
+                if (!window.isListenerInitialized()) {
+                    return;
+                }
+                window.makeCurrent();
+                gl20.glViewport(0, 0, backBufferWidth, backBufferHeight);
+                window.getListener().resize(getWidth(), getHeight());
+                update();
+                window.getListener().render();
+                GLFW.glfwSwapBuffers(windowHandle);
             } else {
-                if (posted) return;
-                posted = true;
-                Gdx.app.postRunnable(new Runnable() {
-                    @Override
-                    public void run () {
-                        posted = false;
-                        renderWindow(windowHandle, width, height);
-                    }
-                });
+                window.asyncResized = true;
             }
         }
     };
-
-    private void renderWindow (long windowHandle, final int width, final int height) {
-        updateFramebufferInfo();
-        if (!window.isListenerInitialized()) {
-            return;
-        }
-        window.makeCurrent();
-        gl20.glViewport(0, 0, backBufferWidth, backBufferHeight);
-        window.getListener().resize(getWidth(), getHeight());
-        window.getListener().render();
-        GLFW.glfwSwapBuffers(windowHandle);
-    }
 
     public Lwjgl3Graphics (Lwjgl3Window window) {
         this.window = window;

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3Net.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3Net.java
@@ -27,6 +27,7 @@ import com.badlogic.gdx.net.ServerSocket;
 import com.badlogic.gdx.net.ServerSocketHints;
 import com.badlogic.gdx.net.Socket;
 import com.badlogic.gdx.net.SocketHints;
+import com.badlogic.gdx.utils.Os;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 /** LWJGL implementation of the {@link Net} API, it could be reused in other Desktop backends since it doesn't depend on LWJGL.
@@ -50,6 +51,11 @@ public class Lwjgl3Net implements Net {
     }
 
     @Override
+    public boolean isHttpRequestPending (HttpRequest httpRequest) {
+        return netJavaImpl.isHttpRequestPending(httpRequest);
+    }
+
+    @Override
     public ServerSocket newServerSocket (Protocol protocol, String ipAddress, int port, ServerSocketHints hints) {
         return new NetJavaServerSocketImpl(protocol, ipAddress, port, hints);
     }
@@ -66,7 +72,7 @@ public class Lwjgl3Net implements Net {
 
     @Override
     public boolean openURI (String uri) {
-        if (SharedLibraryLoader.isMac) {
+        if (SharedLibraryLoader.os == Os.MacOsX) {
             try {
                 (new ProcessBuilder("open", (new URI(uri).toString()))).start();
                 return true;
@@ -80,7 +86,7 @@ public class Lwjgl3Net implements Net {
             } catch (Throwable t) {
                 return false;
             }
-        } else if (SharedLibraryLoader.isLinux) {
+        } else if (SharedLibraryLoader.os == Os.Linux) {
             try {
                 (new ProcessBuilder("xdg-open", (new URI(uri).toString()))).start();
                 return true;

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3VulkanApplication.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3VulkanApplication.java
@@ -84,11 +84,11 @@ public class Lwjgl3VulkanApplication implements Lwjgl3ApplicationBase {
 
     static void initializeGlfw () {
         if (errorCallback == null) {
-            if (SharedLibraryLoader.os == Os.MacOsX) loadGlfwAwtMacos();
             Lwjgl3NativesLoader.load();
             errorCallback = GLFWErrorCallback.createPrint(Lwjgl3ApplicationConfiguration.errorStream);
             GLFW.glfwSetErrorCallback(errorCallback);
-            if (SharedLibraryLoader.os == Os.MacOsX) GLFW.glfwInitHint(GLFW.GLFW_ANGLE_PLATFORM_TYPE, GLFW.GLFW_ANGLE_PLATFORM_TYPE_METAL);
+            if (SharedLibraryLoader.os == Os.MacOsX)
+                GLFW.glfwInitHint(GLFW.GLFW_ANGLE_PLATFORM_TYPE, GLFW.GLFW_ANGLE_PLATFORM_TYPE_METAL);
             GLFW.glfwInitHint(GLFW.GLFW_JOYSTICK_HAT_BUTTONS, GLFW.GLFW_FALSE);
             if (!GLFW.glfwInit()) {
                 throw new GdxRuntimeException("Unable to initialize GLFW");
@@ -109,20 +109,6 @@ public class Lwjgl3VulkanApplication implements Lwjgl3ApplicationBase {
             ANGLELoader.postGlfwInit();
         } catch (Throwable t) {
             throw new GdxRuntimeException("Couldn't load ANGLE.", t);
-        }
-    }
-
-    static void loadGlfwAwtMacos () {
-        try {
-            Class loader = Class.forName("com.badlogic.gdx.backends.lwjgl3.awt.GlfwAWTLoader");
-            Method load = loader.getMethod("load");
-            File sharedLib = (File)load.invoke(loader);
-            Configuration.GLFW_LIBRARY_NAME.set(sharedLib.getAbsolutePath());
-            Configuration.GLFW_CHECK_THREAD0.set(false);
-        } catch (ClassNotFoundException t) {
-            return;
-        } catch (Throwable t) {
-            throw new GdxRuntimeException("Couldn't load GLFW AWT for macOS.", t);
         }
     }
 

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Graphics.DisplayMode;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3DisplayMode;
 import com.badlogic.gdx.graphics.Color;
 
 public class Lwjgl3WindowConfiguration {
@@ -37,7 +38,7 @@ public class Lwjgl3WindowConfiguration {
     FileType windowIconFileType;
     String[] windowIconPaths;
     Lwjgl3WindowListener windowListener;
-    Lwjgl3Graphics.Lwjgl3DisplayMode fullscreenMode;
+    Lwjgl3DisplayMode fullscreenMode;
     String title;
     Color initialBackgroundColor = Color.BLACK;
     boolean initialVisible = true;
@@ -146,7 +147,7 @@ public class Lwjgl3WindowConfiguration {
     /** Sets the app to use fullscreen mode. Use the static methods like {@link Lwjgl3ApplicationConfiguration#getDisplayMode()} on
      * this class to enumerate connected monitors and their fullscreen display modes. */
     public void setFullscreenMode (DisplayMode mode) {
-        this.fullscreenMode = (Lwjgl3Graphics.Lwjgl3DisplayMode)mode;
+        this.fullscreenMode = (Lwjgl3DisplayMode)mode;
     }
 
     /** Sets the window title. If null, the application listener's class name is used. */

--- a/src/main/java/com/github/dgzt/gdx/lwjgl3/angle/ANGLELoader.java
+++ b/src/main/java/com/github/dgzt/gdx/lwjgl3/angle/ANGLELoader.java
@@ -199,18 +199,11 @@ public class ANGLELoader {
         vulkan = getExtractedFile(crc, new File(vulkanSource).getName());
 
         extractFile(eglSource, egl);
+        System.load(egl.getAbsolutePath());
         extractFile(glesSource, gles);
+        System.load(gles.getAbsolutePath());
         extractFile(vulkanSource, vulkan);
-
-        if (Configuration.EGL_LIBRARY_NAME.get() == null) {
-            Configuration.EGL_LIBRARY_NAME.set(egl.getAbsolutePath());
-        }
-        if (Configuration.OPENGLES_LIBRARY_NAME.get() == null) {
-            Configuration.OPENGLES_LIBRARY_NAME.set(gles.getAbsolutePath());
-        }
-
-        GLFWNativeEGL.setEGLPath(EGL.getFunctionProvider());
-        GLFWNativeEGL.setGLESPath(GLES.getFunctionProvider());
+        System.load(vulkan.getAbsolutePath());
     }
 
     public static void postGlfwInit () {


### PR DESCRIPTION
This is an update for the gdx-lwjgl3-angle-vulkan to support the latest version of libGDX. However, this causes a JVM crash when creating a window in Windows 11 I tested, whereas using the libGDX 1.12.1 backend doesn't. I don't know why or how to fix it, but it needs to be investigated.